### PR TITLE
Support MongoDB 7.0 and 8.0 in $currentOp pipeline

### DIFF
--- a/src/close_mongo_ops_manager/mongodb_manager.py
+++ b/src/close_mongo_ops_manager/mongodb_manager.py
@@ -22,6 +22,27 @@ class MongoDBManager:
         self.admin_db: AsyncDatabase | None = None
         self.namespace: str = ""
         self.hide_system_ops: bool = True
+        # (major, minor) — populated on connect; (0, 0) means unknown so we
+        # fall back to the most conservative feature set.
+        self.server_version: tuple[int, int] = (0, 0)
+
+    @staticmethod
+    def _parse_server_version(version: str) -> tuple[int, int]:
+        """Parse "X.Y[.Z][-suffix]" → (X, Y). Returns (0, 0) on failure."""
+        if not isinstance(version, str):
+            return (0, 0)
+        head = version.split("-", 1)[0]
+        parts = head.split(".")
+        try:
+            major = int(parts[0])
+            minor = int(parts[1]) if len(parts) > 1 else 0
+        except (ValueError, IndexError):
+            return (0, 0)
+        return (major, minor)
+
+    def _supports_truncate_ops(self) -> bool:
+        """truncateOps was added in MongoDB 7.1; ship it on 7.1+ and 8.x+."""
+        return self.server_version >= (7, 1)
 
     async def close(self) -> None:
         """Close all MongoDB connections properly."""
@@ -69,7 +90,11 @@ class MongoDBManager:
             server_status = await self.admin_db.command("serverStatus")
             version = server_status.get("version", "unknown version")
             process = server_status.get("process", "unknown process")
-            logger.info(f"Connected to MongoDB {version} ({process})")
+            self.server_version = self._parse_server_version(version)
+            logger.info(
+                f"Connected to MongoDB {version} ({process}); "
+                f"parsed version {self.server_version}"
+            )
 
             return self
         except PyMongoError as e:
@@ -82,8 +107,11 @@ class MongoDBManager:
             return []
 
         try:
-            # Base currentOp arguments
-            current_op_args = {
+            # Base $currentOp arguments. truncateOps (7.1+) lets the server
+            # cap oversized command/originatingCommand payloads so a single
+            # bulk op can't flood the TUI. MongoDB 7.0 rejects unknown
+            # fields, so it's gated on server version.
+            current_op_args: dict[str, Any] = {
                 "allUsers": True,
                 "idleConnections": False,
                 "idleCursors": False,
@@ -91,6 +119,8 @@ class MongoDBManager:
                 "localOps": False,
                 "backtrace": False,
             }
+            if self._supports_truncate_ops():
+                current_op_args["truncateOps"] = True
 
             pipeline = [{"$currentOp": current_op_args}]
 
@@ -188,7 +218,10 @@ class MongoDBManager:
             if match_stage["$and"]:
                 pipeline.append({"$match": match_stage})
 
-            # Project only the fields we need to reduce data transfer
+            # Project only the fields we need to reduce data transfer.
+            # The MongoDB 8.0 group adds queryFramework, cursor, progress,
+            # msg, numYields, appName, host, connectionId, write/prepare
+            # conflicts, throughput, twoPhaseCommitCoordinator, and shard.
             pipeline.append(
                 {
                     "$project": {
@@ -199,18 +232,32 @@ class MongoDBManager:
                         "client": 1,
                         "client_s": 1,
                         "clientMetadata.mongos.host": 1,
+                        "appName": 1,
+                        "host": 1,
+                        "connectionId": 1,
                         "desc": 1,
                         "effectiveUsers": 1,
                         "active": 1,
                         "ns": 1,
                         "command": 1,
                         "planSummary": 1,
+                        "queryFramework": 1,
+                        "cursor": 1,
+                        "progress": 1,
+                        "msg": 1,
+                        "numYields": 1,
                         "currentOpTime": 1,
                         "microsecs_running": 1,
                         "killPending": 1,
                         "WiredTigerTxn": 1,
                         "lsid": 1,
                         "transaction": 1,
+                        "prepareReadConflicts": 1,
+                        "writeConflicts": 1,
+                        "dataThroughputLastSecond": 1,
+                        "dataThroughputAverage": 1,
+                        "twoPhaseCommitCoordinator": 1,
+                        "shard": 1,
                         "locks": 1,
                         "waitingForLock": 1,
                         "lockStats": 1,

--- a/src/close_mongo_ops_manager/operation_details_screen.py
+++ b/src/close_mongo_ops_manager/operation_details_screen.py
@@ -84,47 +84,178 @@ class OperationDetailsScreen(ModalScreen):
     def compose(self) -> ComposeResult:
         with ScrollableContainer(id="details-container"):
             with VerticalScroll(id="details-content"):
-                # Format operation details
-                details = []
-                details.append(f"Operation ID: {self.operation.get('opid', 'N/A')}")
-                details.append(f"Type: {self.operation.get('op', 'N/A')}")
-                details.append(f"Namespace: {self.operation.get('ns', 'N/A')}")
-                details.append(
-                    f"Running Time: {self.operation.get('secs_running', 0)}s"
-                )
+                op = self.operation
+                details: list[str] = []
+                details.append(f"Operation ID: {op.get('opid', 'N/A')}")
+                details.append(f"Type: {op.get('op', 'N/A')}")
+                details.append(f"Namespace: {op.get('ns', 'N/A')}")
+
+                secs_running = op.get("secs_running", 0)
+                microsecs_running = op.get("microsecs_running")
+                if microsecs_running is not None:
+                    details.append(
+                        f"Running Time: {secs_running}s ({microsecs_running}µs)"
+                    )
+                else:
+                    details.append(f"Running Time: {secs_running}s")
+
+                if op.get("active") is not None:
+                    details.append(f"Active: {op.get('active')}")
+
                 # Get client info with fallbacks
-                client_info = (
-                    self.operation.get("client_s")
-                    or self.operation.get("client")
-                    or "N/A"
-                )
+                client_info = op.get("client_s") or op.get("client") or "N/A"
 
                 # Add mongos host info if available
                 mongos_host = (
-                    self.operation.get("clientMetadata", {})
-                    .get("mongos", {})
-                    .get("host", "")
+                    op.get("clientMetadata", {}).get("mongos", {}).get("host", "")
                 )
                 if mongos_host:
-                    # Extract first part of hostname for brevity
                     short_host = mongos_host.split(".", 1)[0]
                     client_info = f"{client_info} ({short_host})"
 
                 details.append(f"Client: {client_info}")
 
-                # Format command details
-                command = self.operation.get("command", {})
+                app_name = op.get("appName")
+                if app_name:
+                    details.append(f"App Name: {app_name}")
+
+                host = op.get("host")
+                connection_id = op.get("connectionId")
+                if host or connection_id is not None:
+                    host_str = host or "N/A"
+                    if connection_id is not None:
+                        host_str = f"{host_str} (conn {connection_id})"
+                    details.append(f"Server: {host_str}")
+
+                desc = op.get("desc")
+                if desc:
+                    details.append(f"Description: {desc}")
+
+                effective_users = op.get("effectiveUsers") or []
+                if effective_users:
+                    users_str = ", ".join(
+                        f"{u.get('user', '?')}@{u.get('db', '?')}"
+                        for u in effective_users
+                        if u
+                    )
+                    details.append(f"Effective Users: {users_str}")
+
+                msg = op.get("msg")
+                if msg:
+                    details.append(f"\nStatus: {msg}")
+
+                progress = op.get("progress") or {}
+                if progress:
+                    done = progress.get("done")
+                    total = progress.get("total")
+                    if total:
+                        pct = (
+                            (done / total * 100)
+                            if isinstance(done, (int, float))
+                            else 0
+                        )
+                        details.append(f"Progress: {done}/{total} ({pct:.1f}%)")
+                    else:
+                        details.append(f"Progress: {progress}")
+
+                num_yields = op.get("numYields")
+                if num_yields is not None:
+                    details.append(f"Num Yields: {num_yields}")
+
+                query_framework = op.get("queryFramework")
+                if query_framework:
+                    details.append(f"Query Framework: {query_framework}")
+
+                plan_summary = op.get("planSummary")
+                if plan_summary:
+                    details.append(f"Plan Summary: {plan_summary}")
+
+                write_conflicts = op.get("writeConflicts")
+                if write_conflicts:
+                    details.append(f"Write Conflicts: {write_conflicts}")
+
+                prepare_read_conflicts = op.get("prepareReadConflicts")
+                if prepare_read_conflicts:
+                    details.append(f"Prepare Read Conflicts: {prepare_read_conflicts}")
+
+                throughput_last = op.get("dataThroughputLastSecond")
+                throughput_avg = op.get("dataThroughputAverage")
+                if throughput_last is not None or throughput_avg is not None:
+                    details.append(
+                        "Throughput: "
+                        f"last={throughput_last} avg={throughput_avg} bytes/s"
+                    )
+
+                shard = op.get("shard")
+                if shard:
+                    details.append(f"Shard: {shard}")
+
+                cursor = op.get("cursor") or {}
+                if cursor:
+                    details.append("\nCursor:")
+                    for key in (
+                        "cursorId",
+                        "createdDate",
+                        "lastAccessDate",
+                        "nDocsReturned",
+                        "nBatchesReturned",
+                        "noCursorTimeout",
+                        "tailable",
+                        "awaitData",
+                        "planSummary",
+                    ):
+                        if key in cursor:
+                            details.append(f"  {key}: {cursor[key]}")
+
+                transaction = op.get("transaction") or {}
+                if transaction:
+                    details.append("\nTransaction:")
+                    params = transaction.get("parameters") or {}
+                    for key in ("txnNumber", "autocommit"):
+                        if key in params:
+                            details.append(f"  {key}: {params[key]}")
+                    read_concern = params.get("readConcern") or {}
+                    if read_concern.get("level"):
+                        details.append(f"  readConcern.level: {read_concern['level']}")
+                    for key in (
+                        "readTimestamp",
+                        "startWallClockTime",
+                        "timeOpenMicros",
+                        "timeActiveMicros",
+                        "timeInactiveMicros",
+                        "expiryTime",
+                    ):
+                        if key in transaction:
+                            details.append(f"  {key}: {transaction[key]}")
+
+                two_pc = op.get("twoPhaseCommitCoordinator") or {}
+                if two_pc:
+                    details.append("\n2PC Coordinator:")
+                    for key in (
+                        "txnNumber",
+                        "numParticipants",
+                        "state",
+                        "commitStartTime",
+                        "hasRecoveredFromFailover",
+                        "deadline",
+                    ):
+                        if key in two_pc:
+                            details.append(f"  {key}: {two_pc[key]}")
+
+                locks = op.get("locks") or {}
+                if locks:
+                    details.append("\nLocks:")
+                    for key, value in locks.items():
+                        details.append(f"  {key}: {value}")
+                if op.get("waitingForLock"):
+                    details.append("  waitingForLock: True")
+
+                command = op.get("command") or {}
                 if command:
                     details.append("\nCommand Details:")
                     for key, value in command.items():
                         details.append(f"  {key}: {value}")
 
-                # Format plan summary if available
-                plan_summary = self.operation.get("planSummary", "")
-                if plan_summary:
-                    details.append(f"\nPlan Summary: {plan_summary}")
-
-                # Join all details with newlines
                 yield TextArea(
                     "\n".join(details), classes="details-text", read_only=True
                 )

--- a/tests/test_mongodb_manager.py
+++ b/tests/test_mongodb_manager.py
@@ -543,6 +543,100 @@ async def test_operation_exists_unexpected_error(manager: MongoDBManager):
     assert result is False
 
 
+async def test_get_operations_uses_truncate_ops_on_8_0(manager: MongoDBManager):
+    """$currentOp should request truncated commands on MongoDB 8.0."""
+    manager.server_version = (8, 0)
+    await manager.get_operations()
+    pipeline = manager.admin_db.aggregate.call_args[0][0]
+    current_op_stage = next(stage for stage in pipeline if "$currentOp" in stage)
+    assert current_op_stage["$currentOp"]["truncateOps"] is True
+
+
+async def test_get_operations_uses_truncate_ops_on_7_1(manager: MongoDBManager):
+    """truncateOps was introduced in 7.1 — include it on 7.1+."""
+    manager.server_version = (7, 1)
+    await manager.get_operations()
+    pipeline = manager.admin_db.aggregate.call_args[0][0]
+    current_op_stage = next(stage for stage in pipeline if "$currentOp" in stage)
+    assert current_op_stage["$currentOp"].get("truncateOps") is True
+
+
+async def test_get_operations_omits_truncate_ops_on_7_0(manager: MongoDBManager):
+    """MongoDB 7.0 rejects unknown fields — truncateOps must be absent."""
+    manager.server_version = (7, 0)
+    await manager.get_operations()
+    pipeline = manager.admin_db.aggregate.call_args[0][0]
+    current_op_stage = next(stage for stage in pipeline if "$currentOp" in stage)
+    assert "truncateOps" not in current_op_stage["$currentOp"]
+
+
+async def test_get_operations_omits_truncate_ops_when_version_unknown(
+    manager: MongoDBManager,
+):
+    """Unknown server version (parse failure) must fall back to safe behavior."""
+    manager.server_version = (0, 0)
+    await manager.get_operations()
+    pipeline = manager.admin_db.aggregate.call_args[0][0]
+    current_op_stage = next(stage for stage in pipeline if "$currentOp" in stage)
+    assert "truncateOps" not in current_op_stage["$currentOp"]
+
+
+def test_parse_server_version_handles_variants():
+    """Server version parsing tolerates patch suffixes, rc tags, and garbage."""
+    parse = MongoDBManager._parse_server_version
+    assert parse("8.0.4") == (8, 0)
+    assert parse("7.0.18-11") == (7, 0)
+    assert parse("7.1.0-rc1") == (7, 1)
+    assert parse("8") == (8, 0)
+    assert parse("unknown version") == (0, 0)
+    assert parse("") == (0, 0)
+    assert parse(None) == (0, 0)  # type: ignore[arg-type]
+
+
+async def test_connect_parses_server_version(mock_async_mongo_client):
+    """Connect should record server_version from serverStatus.version."""
+    from unittest.mock import patch
+
+    # Make serverStatus return a real version string
+    async def command_side_effect(cmd, **kwargs):
+        if cmd == "serverStatus":
+            return {"ok": 1, "version": "8.0.4", "process": "mongod"}
+        return {"ok": 1}
+
+    mock_async_mongo_client.admin.command = AsyncMock(side_effect=command_side_effect)
+
+    with patch(
+        "close_mongo_ops_manager.mongodb_manager.AsyncMongoClient",
+        return_value=mock_async_mongo_client,
+    ):
+        m = await MongoDBManager.connect("mongodb://localhost:27017", "", True)
+        assert m.server_version == (8, 0)
+
+
+async def test_get_operations_projects_mongodb_8_fields(manager: MongoDBManager):
+    """Projection should include the MongoDB 8.0 fields used by the UI."""
+    await manager.get_operations()
+    pipeline = manager.admin_db.aggregate.call_args[0][0]
+    project_stage = next(stage for stage in pipeline if "$project" in stage)["$project"]
+    for field in (
+        "queryFramework",
+        "cursor",
+        "progress",
+        "msg",
+        "numYields",
+        "appName",
+        "host",
+        "connectionId",
+        "prepareReadConflicts",
+        "writeConflicts",
+        "dataThroughputLastSecond",
+        "dataThroughputAverage",
+        "twoPhaseCommitCoordinator",
+        "shard",
+    ):
+        assert project_stage.get(field) == 1, f"missing projection for {field}"
+
+
 async def test_kill_operation_all_retries_exhausted(manager: MongoDBManager):
     """Test kill operation when all retries fail."""
     from close_mongo_ops_manager.exceptions import OperationError

--- a/tests/test_operation_details_screen.py
+++ b/tests/test_operation_details_screen.py
@@ -96,6 +96,62 @@ async def test_details_missing_fields_show_fallback():
         assert "Namespace: N/A" in content
 
 
+async def test_details_displays_mongodb_8_fields():
+    """MongoDB 8.0 fields should render when present."""
+    op = {
+        "opid": 42,
+        "op": "getmore",
+        "ns": "test.col",
+        "secs_running": 3,
+        "microsecs_running": 3_456_789,
+        "client": "10.0.0.1:5000",
+        "appName": "ETL-runner",
+        "host": "shard-0:27017",
+        "connectionId": 88,
+        "numYields": 7,
+        "queryFramework": "sbe",
+        "msg": "Index Build: scanning collection",
+        "progress": {"done": 250, "total": 1000},
+        "writeConflicts": 4,
+        "dataThroughputLastSecond": 1024,
+        "dataThroughputAverage": 2048,
+        "shard": "shard-0",
+        "cursor": {
+            "cursorId": 99,
+            "nDocsReturned": 500,
+            "tailable": False,
+        },
+        "transaction": {
+            "parameters": {
+                "txnNumber": 5,
+                "autocommit": False,
+                "readConcern": {"level": "snapshot"},
+            },
+            "timeOpenMicros": 12345,
+        },
+        "command": {"getMore": 99, "collection": "col"},
+    }
+    app = DetailsTestApp(op)
+    async with app.run_test() as pilot:
+        await pilot.pause(0.1)
+        content = app.screen.query_one(TextArea).text
+
+    assert "App Name: ETL-runner" in content
+    assert "Server: shard-0:27017 (conn 88)" in content
+    assert "Num Yields: 7" in content
+    assert "Query Framework: sbe" in content
+    assert "Status: Index Build: scanning collection" in content
+    assert "Progress: 250/1000 (25.0%)" in content
+    assert "Write Conflicts: 4" in content
+    assert "Throughput: last=1024 avg=2048 bytes/s" in content
+    assert "Shard: shard-0" in content
+    assert "Cursor:" in content
+    assert "cursorId: 99" in content
+    assert "Transaction:" in content
+    assert "txnNumber: 5" in content
+    assert "readConcern.level: snapshot" in content
+
+
 async def test_details_escape_dismisses():
     """Test that pressing Escape dismisses the details screen."""
     op = {"opid": 1, "op": "query", "ns": "test.col"}


### PR DESCRIPTION
## Summary
- Detect server version on connect and parse `serverStatus.version` into `(major, minor)`; gate `truncateOps` (added in MongoDB 7.1) so the tool keeps working against 7.0, which rejects unknown `$currentOp` fields.
- Extend the `$project` stage with MongoDB 8.0 fields: `queryFramework`, `cursor`, `progress`, `msg`, `numYields`, `appName`, `host`, `connectionId`, `prepareReadConflicts`, `writeConflicts`, `dataThroughputLastSecond`, `dataThroughputAverage`, `twoPhaseCommitCoordinator`, `shard`. Projecting a field that doesn't exist on a 7.0 doc is a no-op, so the projection itself is back-compat.
- Render the new fields in `OperationDetailsScreen` when present (status msg, progress %, cursor block, transaction params incl. `readConcern.level`, 2PC coordinator, throughput, shard, app name, host+conn id, numYields, queryFramework).

## Test plan
- [x] `uv run pytest -v` — 119 passed
- [x] `uv run ruff check src/ tests/`
- [x] `uv run ruff format --check src/ tests/`
- [x] Unit tests cover 7.0, 7.1, 8.0, and unparseable-version paths for `truncateOps`, plus a version-string parser test and an end-to-end connect-parses-version test
- [x] Manual smoke against a real 7.0 cluster
- [x] Manual smoke against a real 8.0 cluster